### PR TITLE
Bug/nosquares

### DIFF
--- a/core/src/main/scala/quasar/plugin/sqlserver/SQLServerHygiene.scala
+++ b/core/src/main/scala/quasar/plugin/sqlserver/SQLServerHygiene.scala
@@ -24,10 +24,19 @@ import cats.implicits._
 
 object SQLServerHygiene extends Hygiene {
   final case class HygienicIdent(asIdent: Ident) extends Hygienic {
-    def forSql = asIdent.asString.split('.').map('[' + _ + ']').toList.intercalate(".")
-    def unsafeString = asIdent.asString
+    def forSql: String =
+      asIdent.asString.split('.').map('[' + _ + ']').toList.intercalate(".")
+
+    def unsafeForSqlName: String = elideBrackets(asIdent.asString)
+
+    def forSqlName: String = '[' + unsafeForSqlName + ']'
   }
 
   def hygienicIdent(ident: Ident): HygienicIdent =
     HygienicIdent(ident)
+
+  def elideBrackets(input: String): String =
+    input
+      .replaceAllLiterally("[", "_")
+      .replaceAllLiterally("]", "_")
 }

--- a/destination/src/main/scala/quasar/plugin/sqlserver/destination/CSVCreateSink.scala
+++ b/destination/src/main/scala/quasar/plugin/sqlserver/destination/CSVCreateSink.scala
@@ -61,20 +61,20 @@ private[destination] object CsvCreateSink {
     val obj = jdbc.resourcePathRef(pathWithSchema).get // FIXME
 
     val objFragment: Fragment = obj.fold(
-      t => Fragment.const0(SQLServerHygiene.hygienicIdent(t).forSql),
+      t => Fragment.const0(SQLServerHygiene.hygienicIdent(t).forSqlName),
       { case (d, t) =>
-        Fragment.const0(SQLServerHygiene.hygienicIdent(d).forSql) ++
-        fr0"." ++
-        Fragment.const0(SQLServerHygiene.hygienicIdent(t).forSql)
+        Fragment.const0(SQLServerHygiene.hygienicIdent(d).forSqlName) ++
+          fr0"." ++
+          Fragment.const0(SQLServerHygiene.hygienicIdent(t).forSqlName)
       })
 
     val unsafeTableName: String = obj.fold(
-      t => t.asString,
-      { case (_, t) => t.asString})
+      t => SQLServerHygiene.hygienicIdent(t).unsafeForSqlName,
+      { case (_, t) => SQLServerHygiene.hygienicIdent(t).unsafeForSqlName})
 
     val unsafeTableSchema: Option[String] = obj.fold(
       _ => None,
-      { case (d, _) => Some(d.asString) })
+      { case (d, _) => Some(SQLServerHygiene.hygienicIdent(d).unsafeForSqlName) })
 
     def doLoad(obj: Fragment): Pipe[F, CharSequence, Unit] = in => {
       def insert(prefix: StringBuilder, length: Int): Stream[F, Unit] =

--- a/destination/src/main/scala/quasar/plugin/sqlserver/destination/SQLServerDestinationModule.scala
+++ b/destination/src/main/scala/quasar/plugin/sqlserver/destination/SQLServerDestinationModule.scala
@@ -89,7 +89,6 @@ object SQLServerDestinationModule extends JdbcDestinationModule[DestinationConfi
       : Resource[F, Either[InitError, Destination[F]]] = {
     val schema = config.schema.getOrElse("dbo")
 
-    // TODO test different schema
     (new SQLServerDestination[F](config.writeMode, schema, transactor, log): Destination[F])
       .asRight[InitError]
       .pure[Resource[F, ?]]

--- a/destination/src/main/scala/quasar/plugin/sqlserver/destination/package.scala
+++ b/destination/src/main/scala/quasar/plugin/sqlserver/destination/package.scala
@@ -19,7 +19,6 @@ package quasar.plugin.sqlserver
 import scala._, Predef._
 import java.lang.CharSequence
 
-//import quasar.api.Column
 import quasar.connector.render.RenderConfig
 
 import cats.data.NonEmptyList
@@ -104,13 +103,13 @@ package object destination {
   def createColumnSpecs(cols: NonEmptyList[(HI, SQLServerType)]): Fragment =
     Fragments.parentheses(
       cols
-        .map { case (n, t) => Fragment.const(n.forSql) ++ t.asSql }
+        .map { case (n, t) => Fragment.const(n.forSqlName) ++ t.asSql }
         .intercalate(fr","))
 
   def insertColumnSpecs(cols: NonEmptyList[(HI, SQLServerType)]): Fragment =
     Fragments.parentheses(
       cols
-        .map { case (n, _) => Fragment.const(n.forSql) }
+        .map { case (n, _) => Fragment.const(n.forSqlName) }
         .intercalate(fr","))
 
   def insertIntoPrefix(

--- a/destination/src/test/scala/quasar/plugin/sqlserver/destination/SQLServerDestinationSpec.scala
+++ b/destination/src/test/scala/quasar/plugin/sqlserver/destination/SQLServerDestinationSpec.scala
@@ -16,7 +16,7 @@
 
 package quasar.plugin.sqlserver.destination
 
-import quasar.plugin.sqlserver.TestHarness
+import quasar.plugin.sqlserver._
 
 import scala.{text => _, Stream => _, _}, Predef._
 
@@ -54,9 +54,10 @@ object SQLServerDestinationSpec extends TestHarness with Logging {
   def harnessed(
       jdbcUrl: String = TestUrl(Some(TestDb)),
       writeMode: WriteMode = WriteMode.Replace,
-      schema: String = "dbo")
+      schema: String = "dbo",
+      specialString: String = "")
       : Resource[IO, (Transactor[IO], SQLServerDestination[IO], ResourcePath, String)] =
-    tableHarness(jdbcUrl, false) map {
+    tableHarness(jdbcUrl, false, specialString) map {
       case (xa, path, name) => {
         (xa, new SQLServerDestination(writeMode, schema, xa, log), path, name)
       }
@@ -342,6 +343,42 @@ object SQLServerDestinationSpec extends TestHarness with Logging {
               .query[String].to[List].transact(xa)
         } yield {
           vals must contain(A, B, C)
+        }
+      }
+    }
+
+    "remove open and close brackets in column name" >> {
+      val input = delim("'foobarbaz'")
+      val cols = NonEmptyList.one(Column("[12]foo", VARCHAR(12)))
+
+      harnessed() use { case (xa, dest, path, tableName) =>
+        for {
+          _ <- input.through(createSink(dest, path, cols)).compile.drain
+
+          vals <-
+            frag(s"select [_12_foo] from $tableName")
+              .query[String].to[List].transact(xa)
+        } yield {
+          vals must contain("foobarbaz")
+        }
+      }
+    }
+
+    "remove open and close brackets in table name" >> {
+      val input = delim("'foobarbaz'")
+      val cols = NonEmptyList.one(Column("value", VARCHAR(12)))
+
+      harnessed(specialString = "[test]") use { case (xa, dest, path, tableName) =>
+        for {
+          _ <- input.through(createSink(dest, path, cols)).compile.drain
+
+          name = SQLServerHygiene.elideBrackets(tableName)
+
+          vals <-
+            frag(s"select [value] from [$name]")
+              .query[String].to[List].transact(xa)
+        } yield {
+          vals must contain("foobarbaz")
         }
       }
     }

--- a/destination/src/test/scala/quasar/plugin/sqlserver/destination/SQLServerDestinationSpec.scala
+++ b/destination/src/test/scala/quasar/plugin/sqlserver/destination/SQLServerDestinationSpec.scala
@@ -449,8 +449,7 @@ object SQLServerDestinationSpec extends TestHarness with Logging {
         Column("B", TINYINT),
         Column("C", DATE))
 
-      // bulkCopy.setDestinationTableName cannot handle a number as the first char of a schema name
-      val testSchema = IO("a" ++ Random.alphanumeric.take(5).mkString)
+      val testSchema = IO(Random.alphanumeric.take(6).mkString)
 
       testSchema.flatMap(sch => harnessed(schema = sch) use { case (xa, dest, path, tableName) =>
         for {
@@ -480,8 +479,7 @@ object SQLServerDestinationSpec extends TestHarness with Logging {
         Column("B", TINYINT),
         Column("C", DATE))
 
-      // bulkCopy.setDestinationTableName cannot handle a number as the first char of a schema name
-      val testSchema = IO("a" ++ Random.alphanumeric.take(5).mkString)
+      val testSchema = IO(Random.alphanumeric.take(6).mkString)
 
       testSchema.flatMap(sch => harnessed(schema = sch) use { case (xa, dest, path, tableName) =>
         for {


### PR DESCRIPTION
[ch12534]

Replace `[` and `]` with `_` in table names and column names. Manually tested (via running a push in Precog) that this works for both table names and column names.

Square brackets are not categorically disallowed in SQL Server names, but replacing them with `_` is safe and is within the scope of what a Precog destination can be expected to do when pushing to a destination. And, I did some reading and didn't find a consistent and hygienic way to escape square brackets.