### PR TITLE
Ensure id columns using 'default' string type are indexable

### DIFF
--- a/destination/src/main/scala/quasar/plugin/sqlserver/destination/SQLServerType.scala
+++ b/destination/src/main/scala/quasar/plugin/sqlserver/destination/SQLServerType.scala
@@ -18,6 +18,7 @@ package quasar.plugin.sqlserver.destination
 
 import scala._, Predef._
 
+import cats.Eq
 import cats.data.Ior
 
 import doobie.Fragment
@@ -147,6 +148,9 @@ object SQLServerType {
     val constructor = Constructor.Unary(LengthCharsParam(8000), VARCHAR(_))
   }
 
+  implicit val sqlServerTypeEq: Eq[SQLServerType] =
+    Eq.fromUniversalEquals
+
   ////
 
   private def LengthCharsParam(max: Int): Labeled[Formal[Int]] =
@@ -198,4 +202,7 @@ object SQLServerTypeId {
       TIME,
       TINYINT,
       VARCHAR)
+
+  implicit val sqlServerTypeIdEq: Eq[SQLServerTypeId] =
+    Eq.fromUniversalEquals
 }

--- a/destination/src/main/scala/quasar/plugin/sqlserver/destination/SQLServerType.scala
+++ b/destination/src/main/scala/quasar/plugin/sqlserver/destination/SQLServerType.scala
@@ -27,6 +27,7 @@ import quasar.api.push.param._
 import quasar.connector.destination.Constructor
 
 sealed abstract class SQLServerType(spec: String) extends Product with Serializable {
+  def id: SQLServerTypeId
   def asSql: Fragment = Fragment.const0(spec)
 }
 
@@ -36,7 +37,9 @@ object SQLServerType {
 
   case object BIT extends SQLServerTypeId.SelfIdentified("BIT", 1)
 
-  final case class CHAR(length: Int) extends SQLServerType(s"CHAR($length)")
+  final case class CHAR(length: Int) extends SQLServerType(s"CHAR($length)") {
+    def id = CHAR
+  }
   case object CHAR extends SQLServerTypeId.HigherKinded(2) {
     val constructor = Constructor.Unary(LengthCharsParam(8000), CHAR(_))
   }
@@ -45,17 +48,23 @@ object SQLServerType {
 
   case object DATETIME extends SQLServerTypeId.SelfIdentified("DATETIME", 4)
 
-  final case class DATETIME2(precision: Int) extends SQLServerType(s"DATETIME2($precision)")
+  final case class DATETIME2(precision: Int) extends SQLServerType(s"DATETIME2($precision)") {
+    def id = DATETIME2
+  }
   case object DATETIME2 extends SQLServerTypeId.HigherKinded(5) {
     val constructor = Constructor.Unary(PrecisionDateTimeParam(7), DATETIME2(_))
   }
 
-  final case class DATETIMEOFFSET(precision: Int) extends SQLServerType(s"DATETIMEOFFSET($precision)")
+  final case class DATETIMEOFFSET(precision: Int) extends SQLServerType(s"DATETIMEOFFSET($precision)") {
+    def id = DATETIMEOFFSET
+  }
   case object DATETIMEOFFSET extends SQLServerTypeId.HigherKinded(6) {
     val constructor = Constructor.Unary(PrecisionDateTimeParam(7), DATETIMEOFFSET(_))
   }
 
-  final case class DECIMAL(precision: Int, scale: Int) extends SQLServerType(s"DECIMAL($precision, $scale)")
+  final case class DECIMAL(precision: Int, scale: Int) extends SQLServerType(s"DECIMAL($precision, $scale)") {
+    def id = DECIMAL
+  }
   case object DECIMAL extends SQLServerTypeId.HigherKinded(7) {
     val constructor = {
       val precisionParam: Labeled[Formal[Int]] =
@@ -71,19 +80,25 @@ object SQLServerType {
     }
   }
 
-  final case class FLOAT(precision: Int) extends SQLServerType(s"FLOAT($precision)")
+  final case class FLOAT(precision: Int) extends SQLServerType(s"FLOAT($precision)") {
+    def id = FLOAT
+  }
   case object FLOAT extends SQLServerTypeId.HigherKinded(8) {
     val constructor = Constructor.Unary(PrecisionFloatParam(53), FLOAT(_))
   }
 
   case object INT extends SQLServerTypeId.SelfIdentified("INT", 9)
 
-  final case class NCHAR(length: Int) extends SQLServerType(s"NCHAR($length)")
+  final case class NCHAR(length: Int) extends SQLServerType(s"NCHAR($length)") {
+    def id = NCHAR
+  }
   case object NCHAR extends SQLServerTypeId.HigherKinded(10) {
     val constructor = Constructor.Unary(LengthCharsParam(4000), NCHAR(_))
   }
 
-  final case class NUMERIC(precision: Int, scale: Int) extends SQLServerType(s"NUMERIC($precision, $scale)")
+  final case class NUMERIC(precision: Int, scale: Int) extends SQLServerType(s"NUMERIC($precision, $scale)") {
+    def id = NUMERIC
+  }
   case object NUMERIC extends SQLServerTypeId.HigherKinded(11) {
     val constructor = {
       val precisionParam: Labeled[Formal[Int]] =
@@ -99,7 +114,9 @@ object SQLServerType {
     }
   }
 
-  final case class NVARCHAR(length: Int) extends SQLServerType(s"NVARCHAR($length)")
+  final case class NVARCHAR(length: Int) extends SQLServerType(s"NVARCHAR($length)") {
+    def id = NVARCHAR
+  }
   case object NVARCHAR extends SQLServerTypeId.HigherKinded(12) {
     val constructor = Constructor.Unary(LengthCharsParam(4000), NVARCHAR(_))
   }
@@ -114,14 +131,18 @@ object SQLServerType {
 
   case object TEXT extends SQLServerTypeId.SelfIdentified("TEXT", 17)
 
-  final case class TIME(precision: Int) extends SQLServerType(s"TIME($precision)")
+  final case class TIME(precision: Int) extends SQLServerType(s"TIME($precision)") {
+    def id = TIME
+  }
   case object TIME extends SQLServerTypeId.HigherKinded(18) {
     val constructor = Constructor.Unary(PrecisionDateTimeParam(7), TIME(_))
   }
 
   case object TINYINT extends SQLServerTypeId.SelfIdentified("TINYINT", 19)
 
-  final case class VARCHAR(length: Int) extends SQLServerType(s"VARCHAR($length)")
+  final case class VARCHAR(length: Int) extends SQLServerType(s"VARCHAR($length)") {
+    def id = VARCHAR
+  }
   case object VARCHAR extends SQLServerTypeId.HigherKinded(20) {
     val constructor = Constructor.Unary(LengthCharsParam(8000), VARCHAR(_))
   }
@@ -146,7 +167,9 @@ object SQLServerTypeId {
   import SQLServerType._
 
   sealed abstract class SelfIdentified(spec: String, val ordinal: Int)
-      extends SQLServerType(spec) with SQLServerTypeId
+      extends SQLServerType(spec) with SQLServerTypeId {
+    def id = this
+  }
 
   sealed abstract class HigherKinded(val ordinal: Int) extends SQLServerTypeId {
     def constructor: Constructor[SQLServerType]

--- a/destination/src/main/scala/quasar/plugin/sqlserver/destination/SinkBuilder.scala
+++ b/destination/src/main/scala/quasar/plugin/sqlserver/destination/SinkBuilder.scala
@@ -20,8 +20,8 @@ import slamdata.Predef._
 
 import quasar.plugin.sqlserver._
 
+import quasar.api.{Column, ColumnType}
 import quasar.api.push.OffsetKey
-import quasar.api.Column
 import quasar.api.resource.ResourcePath
 import quasar.connector.{AppendEvent, DataEvent, IdBatch, MonadResourceErr}
 import quasar.connector.destination.{WriteMode => QWriteMode, ResultSink}, ResultSink.{UpsertSink, AppendSink}
@@ -87,7 +87,6 @@ object SinkBuilder {
     (renderConfig(args.columns), consume)
   }
 
-
   private def upsertPipe[F[_]: Effect: MonadResourceErr, A](
       xa: Transactor[F],
       writeMode: QWriteMode,
@@ -100,10 +99,14 @@ object SinkBuilder {
       : Pipe[F, DataEvent[CharSequence, OffsetKey.Actual[A]], OffsetKey.Actual[A]] = { events =>
 
     val logHandler = Slf4sLogHandler(logger)
-
     val toConnectionIO = Effect.toIOK[F] andThen LiftIO.liftK[ConnectionIO]
 
-    val hyColumns = hygienicColumns(inputColumns)
+    val (actualId, actualColumns) = idColumn match {
+      case Some(c) => ensureIndexableIdColumn(c, inputColumns).leftMap(Some(_))
+      case None => (None, inputColumns)
+    }
+
+    val hyColumns = hygienicColumns(actualColumns)
 
     def logEvents(event: DataEvent[CharSequence, _]): F[Unit] = event match {
       case DataEvent.Create(chunk) =>
@@ -124,9 +127,10 @@ object SinkBuilder {
       case DataEvent.Delete(ids) if ids.size < 1 =>
         none[OffsetKey.Actual[A]].pure[ConnectionIO]
 
-      case DataEvent.Delete(ids) => idColumn match {
+      case DataEvent.Delete(ids) => actualId match {
         case None =>
           none[OffsetKey.Actual[A]].pure[ConnectionIO]
+
         case Some(id) =>
           val columnName = SQLServerHygiene.hygienicIdent(Ident(id.name))
 
@@ -161,10 +165,6 @@ object SinkBuilder {
       for {
         (objFragment, unsafeName, unsafeSchema) <- pathFragment[F](schema, path)
 
-        hygienicColumns = inputColumns.map { c =>
-          (SQLServerHygiene.hygienicIdent(Ident(c.name)), c.tpe)
-        }
-
         start = writeMode match {
           case QWriteMode.Replace =>
             (startLoad(logHandler)(
@@ -172,8 +172,8 @@ object SinkBuilder {
               objFragment,
               unsafeName,
               unsafeSchema,
-              hygienicColumns,
-              idColumn) >> commit)
+              hyColumns,
+              actualId) >> commit)
               .transact(xa)
           case QWriteMode.Append =>
             ().pure[F]
@@ -189,4 +189,20 @@ object SinkBuilder {
       } yield Stream.eval_(logStart) ++ Stream.eval_(start) ++ handled ++ Stream.eval_(logEnd)
     }
   }
+
+  /** Ensures the provided identity column is suitable for indexing by SQL Server,
+    * adjusting the type to one that is compatible and indexable if not.
+    */
+  private def ensureIndexableIdColumn(
+      id: Column[SQLServerType],
+      columns: NonEmptyList[Column[SQLServerType]])
+      : (Column[SQLServerType], NonEmptyList[Column[SQLServerType]]) =
+    Typer.inferScalar(id.tpe)
+      .collect {
+        case t @ ColumnType.String if Some(id.tpe) == Typer.preferred(t) =>
+          val indexableId = id.as(SQLServerType.VARCHAR(MaxIndexableVarchars))
+          val cols = columns.map(c => if (c == id) indexableId else c)
+          (indexableId, cols)
+      }
+      .getOrElse((id, columns))
 }

--- a/destination/src/main/scala/quasar/plugin/sqlserver/destination/SinkBuilder.scala
+++ b/destination/src/main/scala/quasar/plugin/sqlserver/destination/SinkBuilder.scala
@@ -31,7 +31,7 @@ import quasar.lib.jdbc.destination.{WriteMode => JWriteMode}
 
 import cats.data.{NonEmptyList, NonEmptyVector}
 import cats.effect.{Effect, LiftIO}
-import cats.implicits._
+import cats.syntax.all._
 
 import doobie._
 import doobie.free.connection.{commit, rollback}
@@ -199,9 +199,9 @@ object SinkBuilder {
       : (Column[SQLServerType], NonEmptyList[Column[SQLServerType]]) =
     Typer.inferScalar(id.tpe)
       .collect {
-        case t @ ColumnType.String if Some(id.tpe) == Typer.preferred(t) =>
+        case t @ ColumnType.String if id.tpe.some === Typer.preferred(t) =>
           val indexableId = id.as(SQLServerType.VARCHAR(MaxIndexableVarchars))
-          val cols = columns.map(c => if (c == id) indexableId else c)
+          val cols = columns.map(c => if (c === id) indexableId else c)
           (indexableId, cols)
       }
       .getOrElse((id, columns))

--- a/destination/src/main/scala/quasar/plugin/sqlserver/destination/Typer.scala
+++ b/destination/src/main/scala/quasar/plugin/sqlserver/destination/Typer.scala
@@ -24,6 +24,7 @@ import quasar.connector.destination.Constructor
 import scala._, Predef._
 
 import cats.data.NonEmptyList
+import cats.syntax.all._
 
 object Typer {
   import Constructor._
@@ -41,7 +42,7 @@ object Typer {
   def inferScalar(tpe: SQLServerType): Option[ColumnType.Scalar] =
     coercions.toList
       .collect {
-        case (k, TypeCoercion.Satisfied(ids)) if ids.exists(_ == tpe.id) => k
+        case (k, TypeCoercion.Satisfied(ids)) if ids.exists(_ === tpe.id) => k
       } match {
         case t :: Nil => Some(t)
         case _ => None

--- a/destination/src/main/scala/quasar/plugin/sqlserver/destination/Typer.scala
+++ b/destination/src/main/scala/quasar/plugin/sqlserver/destination/Typer.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.plugin.sqlserver.destination
+
+import quasar.api.{ColumnType, Labeled}
+import quasar.api.push.TypeCoercion
+import quasar.api.push.param._
+import quasar.connector.destination.Constructor
+
+import scala._, Predef._
+
+import cats.data.NonEmptyList
+
+object Typer {
+  import Constructor._
+  import SQLServerType._
+
+  def coerce(scalarType: ColumnType.Scalar): TypeCoercion[SQLServerTypeId] =
+    coercions(scalarType)
+
+  def construct(id: SQLServerTypeId): Either[SQLServerType, Constructor[SQLServerType]] =
+    id match {
+      case tpe: SQLServerTypeId.SelfIdentified => Left(tpe)
+      case hk: SQLServerTypeId.HigherKinded => Right(hk.constructor)
+    }
+
+  def inferScalar(tpe: SQLServerType): Option[ColumnType.Scalar] =
+    coercions.toList
+      .collect {
+        case (k, TypeCoercion.Satisfied(ids)) if ids.exists(_ == tpe.id) => k
+      } match {
+        case t :: Nil => Some(t)
+        case _ => None
+      }
+
+  /** Returns the "preferred" (highest priority) representation for a scalar
+    * using maximal values for any parameters, when applicable.
+    */
+  def preferred(scalarType: ColumnType.Scalar): Option[SQLServerType] =
+    coerce(scalarType) match {
+      case TypeCoercion.Satisfied(ids) =>
+        construct(ids.head) match {
+          case Left(t) => Some(t)
+          case Right(Unary(Labeled(_, p1), f)) =>
+            Some(f(maximal(p1)))
+          case Right(Binary(Labeled(_, p1), Labeled(_, p2), f)) =>
+            Some(f(maximal(p1), maximal(p2)))
+          case Right(Ternary(Labeled(_, p1), Labeled(_, p2), Labeled(_, p3), f)) =>
+            Some(f(maximal(p1), maximal(p2), maximal(p3)))
+        }
+
+      case TypeCoercion.Unsatisfied(_, _) => None
+    }
+
+  ////
+
+  private val coercions: Map[ColumnType.Scalar, TypeCoercion[SQLServerTypeId]] =
+    Map(
+      ColumnType.Boolean -> satisfied(BIT),
+
+      ColumnType.LocalTime -> satisfied(TIME),
+      ColumnType.LocalDate -> satisfied(DATE),
+      ColumnType.LocalDateTime -> satisfied(DATETIME2, DATETIME, SMALLDATETIME),
+      ColumnType.OffsetDateTime -> satisfied(DATETIMEOFFSET),
+
+      ColumnType.OffsetTime ->
+        TypeCoercion.Unsatisfied(List(ColumnType.LocalTime), None),
+
+      ColumnType.OffsetDate ->
+        TypeCoercion.Unsatisfied(List(ColumnType.LocalDate), None),
+
+      ColumnType.Number ->
+        satisfied(
+          FLOAT,
+          INT,
+          DECIMAL,
+          BIGINT,
+          NUMERIC,
+          REAL,
+          SMALLINT,
+          TINYINT),
+
+      ColumnType.String ->
+        satisfied(
+          TEXT,
+          NTEXT,
+          NCHAR,
+          NVARCHAR,
+          CHAR,
+          VARCHAR)
+    ).withDefaultValue(TypeCoercion.Unsatisfied(Nil, None))
+
+  private def maximal[A](formal: Formal[A]): Option[A] = {
+    import ParamType._
+
+    formal match {
+      case Boolean(_) => Some(true)
+      case Integer(Integer.Args(bounds, step, defaultValue)) =>
+        Some((defaultValue orElse bounds.map(_.fold(
+          x => x,
+          x => x,
+          { case (min, max) => max }))
+        ).getOrElse(0))
+      case Enum(ps) => Some(ps.head._2)
+      case EnumSelect(_) => None
+    }
+  }
+
+  private def satisfied(t: SQLServerTypeId, ts: SQLServerTypeId*) =
+    TypeCoercion.Satisfied(NonEmptyList(t, ts.toList))
+}

--- a/destination/src/main/scala/quasar/plugin/sqlserver/destination/package.scala
+++ b/destination/src/main/scala/quasar/plugin/sqlserver/destination/package.scala
@@ -37,7 +37,12 @@ import doobie.implicits._
 import fs2.Chunk
 
 package object destination {
-  val NullSentinel = ""
+  /** The maximum width, in characters, of an indexable VARCHAR column such that SQL server
+    * will allow an index to be created for it.
+    */
+  val MaxIndexableVarchars: Int = 900
+
+  val NullSentinel: String = ""
 
   def renderConfig(cols: NonEmptyList[Column[SQLServerType]]): RenderConfig[CharSequence] =
     RenderConfig.Separated(",", SQLServerColumnRender(cols))

--- a/destination/src/test/scala/quasar/plugin/sqlserver/destination/SQLServerDestinationSeekSinksSpec.scala
+++ b/destination/src/test/scala/quasar/plugin/sqlserver/destination/SQLServerDestinationSeekSinksSpec.scala
@@ -82,7 +82,7 @@ object SQLServerDestinationSeekSinksSpec extends EffectfulQSpec[IO] with BeforeA
   val Mod = SQLServerDestinationModule
 
   "seek sinks (upsert and append)" should {
-    val XStringCol = Column("x", SQLServerType.NVARCHAR(255))
+    val XStringCol = Column("x", SQLServerType.TEXT)
     "write after commit" >> Consumer.appendAndUpsert[String :: String :: HNil] { (toOpt, consumer) =>
       val events =
         Stream(
@@ -630,7 +630,7 @@ object SQLServerDestinationSeekSinksSpec extends EffectfulQSpec[IO] with BeforeA
 
   object columnType extends Poly1 {
     import SQLServerType._
-    implicit val stringCase: Case.Aux[String, SQLServerType] = at(_ => NVARCHAR(255))
+    implicit val stringCase: Case.Aux[String, SQLServerType] = at(_ => TEXT)
     implicit val intCase: Case.Aux[Int, SQLServerType] = at(_ => INT)
   }
 


### PR DESCRIPTION
Adjusts the representation of a `ColumnType.String` identity column to something indexable if the default type used to represent it isn't (e.g. the current use of `TEXT`).

[ch13019]